### PR TITLE
Add the Accord benchmark to easy stress

### DIFF
--- a/src/main/kotlin/com/rustyrazorblade/easycassstress/workloads/TxnCounter.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycassstress/workloads/TxnCounter.kt
@@ -6,10 +6,42 @@ import com.rustyrazorblade.easycassstress.StressContext
 import com.rustyrazorblade.easycassstress.WorkloadParameter
 
 enum class Impl {
+    /**
+     * Lightweight Transactions - uses Cassandra's native conditional updates with IF EXISTS
+     * to ensure atomicity of counter operations.
+     */
     LWT,
+
+    /**
+     * Accord Transaction Protocol - uses Cassandra's newer transaction protocol designed
+     * to handle distributed transactions with multiple key support and more flexible logic.
+     */
     ACCORD,
 }
 
+/**
+ * A stress profile that tests distributed counters using different transaction algorithms in Apache Cassandra.
+ * This workload simulates concurrent increments of counter values using either Lightweight Transactions (LWT)
+ * or Accord transaction protocol, allowing performance comparison between these transaction mechanisms.
+ *
+ * The test helps evaluate the consistency and performance characteristics of distributed counter operations
+ * under high concurrency conditions.
+ *
+ * Example:
+ * ```
+ * # Run with LWT implementation (default)
+ * cassandra-easy-stress run TxnCounter
+ * 
+ * # Run with Accord implementation
+ * cassandra-easy-stress run TxnCounter --workload.impl=ACCORD
+ * 
+ * # Specify explicit reads with Accord implementation
+ * cassandra-easy-stress run TxnCounter --workload.impl=ACCORD --workload.accordAutoRead=false
+ * 
+ * # Add a custom postfix to table names
+ * cassandra-easy-stress run TxnCounter --workload.postfix=test_run1
+ * ```
+ */
 class TxnCounter : IStressProfile {
     @WorkloadParameter("Which type of transaction system to use")
     var impl = Impl.LWT

--- a/src/main/kotlin/com/rustyrazorblade/easycassstress/workloads/TxnCounter.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycassstress/workloads/TxnCounter.kt
@@ -31,13 +31,13 @@ enum class Impl {
  * ```
  * # Run with LWT implementation (default)
  * cassandra-easy-stress run TxnCounter
- * 
+ *
  * # Run with Accord implementation
  * cassandra-easy-stress run TxnCounter --workload.impl=ACCORD
- * 
+ *
  * # Specify explicit reads with Accord implementation
  * cassandra-easy-stress run TxnCounter --workload.impl=ACCORD --workload.accordAutoRead=false
- * 
+ *
  * # Add a custom postfix to table names
  * cassandra-easy-stress run TxnCounter --workload.postfix=test_run1
  * ```

--- a/src/main/kotlin/com/rustyrazorblade/easycassstress/workloads/TxnCounter.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycassstress/workloads/TxnCounter.kt
@@ -1,0 +1,152 @@
+package com.rustyrazorblade.easycassstress.workloads
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.rustyrazorblade.easycassstress.PartitionKey
+import com.rustyrazorblade.easycassstress.StressContext
+import com.rustyrazorblade.easycassstress.WorkloadParameter
+
+enum class Impl {
+    LWT,
+    ACCORD,
+}
+
+class TxnCounter : IStressProfile {
+    @WorkloadParameter("Which type of transaction system to use")
+    var impl = Impl.LWT
+
+    @WorkloadParameter("Be implicit or explicit about the update read; false means be explicit, true means be implicit")
+    var accordAutoRead: Boolean = true
+
+    @WorkloadParameter("A postfix added to the table name")
+    var postfix: String = ""
+
+    private fun name() = "tx_${impl.name.lowercase()}_counter${if (postfix.isEmpty()) "" else "_$postfix"}"
+
+    override fun schema(): List<String> =
+        listOf(
+            """
+            CREATE TABLE IF NOT EXISTS ${name()} (
+                id TEXT PRIMARY KEY,
+                value INT
+            )
+            ${if (impl == Impl.ACCORD) "WITH transactional_mode='full'" else ""}
+            """.trimIndent(),
+        )
+
+    override fun prepare(session: CqlSession) {}
+
+    override fun getRunner(context: StressContext): IStressRunner =
+        when (impl) {
+            Impl.LWT -> lwtRunner(context)
+            Impl.ACCORD -> accordRunner(context)
+        }
+
+    private fun lwtRunner(context: StressContext): IStressRunner =
+        object : IStressRunner {
+            val prepareInsert =
+                context.session.prepare(
+                    """
+                    INSERT INTO ${name()} (id, value) VALUES (?, ?) IF NOT EXISTS
+                    """.trimIndent(),
+                )
+            val update =
+                context.session.prepare(
+                    """
+                    UPDATE ${name()}
+                    SET value = value + 1
+                    WHERE id = ?
+                    IF EXISTS
+                    """.trimIndent(),
+                )
+            val select =
+                context.session.prepare(
+                    """
+                    SELECT *
+                    FROM ${name()}
+                    WHERE id = ?
+                    """.trimIndent(),
+                )
+
+            override fun getNextMutation(partitionKey: PartitionKey): Operation = Operation.Mutation(update.bind(partitionKey.getText()))
+
+            override fun getNextPopulate(partitionKey: PartitionKey): Operation =
+                Operation.Mutation(prepareInsert.bind(partitionKey.getText(), 0))
+
+            override fun getNextSelect(partitionKey: PartitionKey): Operation {
+                val bind = select.bind(partitionKey.getText())
+                bind.serialConsistencyLevel = context.mainArguments.serialConsistencyLevel
+                return Operation.SelectStatement(bind)
+            }
+
+            override fun getNextDelete(partitionKey: PartitionKey): Operation {
+                TODO("Counter test does not support delete")
+            }
+        }
+
+    private fun accordRunner(context: StressContext): IStressRunner =
+        object : IStressRunner {
+            val prepareInsert =
+                context.session.prepare(
+                    """
+                    BEGIN TRANSACTION
+                        LET a = (SELECT * FROM ${name()} WHERE id = ?);
+                        IF a IS NULL THEN
+                            INSERT INTO ${name()} (id, value)
+                            VALUES (?, 0);
+                        END IF
+                    COMMIT TRANSACTION
+                    """.trimIndent(),
+                )
+            val update =
+                context.session.prepare(
+                    if (accordAutoRead) {
+                        """
+                        BEGIN TRANSACTION
+                            UPDATE ${name()}
+                              SET value += 1
+                              WHERE id = ?;
+                        COMMIT TRANSACTION
+                        """.trimIndent()
+                    } else {
+                        """
+                        BEGIN TRANSACTION
+                            LET a = (SELECT * FROM ${name()} WHERE id = ?);
+                            IF a IS NOT NULL THEN
+                                UPDATE ${name()}
+                                  SET value = a.value + 1
+                                  WHERE id = ?;
+                            END IF
+                        COMMIT TRANSACTION
+                        """.trimIndent()
+                    },
+                )
+            val select =
+                context.session.prepare(
+                    """
+                    BEGIN TRANSACTION
+                        SELECT *
+                          FROM ${name()}
+                          WHERE id = ?;
+                    COMMIT TRANSACTION
+                    """.trimIndent(),
+                )
+
+            override fun getNextMutation(partitionKey: PartitionKey): Operation =
+                Operation.Mutation(
+                    if (accordAutoRead) {
+                        update.bind(partitionKey)
+                    } else {
+                        update.bind(partitionKey, partitionKey)
+                    },
+                )
+
+            override fun getNextPopulate(partitionKey: PartitionKey): Operation =
+                Operation.Mutation(prepareInsert.bind(partitionKey, partitionKey))
+
+            override fun getNextSelect(partitionKey: PartitionKey): Operation = Operation.SelectStatement(select.bind(partitionKey))
+
+            override fun getNextDelete(partitionKey: PartitionKey): Operation {
+                TODO("Counter test does not support delete")
+            }
+        }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easycassstress/workloads/TxnCounter.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycassstress/workloads/TxnCounter.kt
@@ -166,16 +166,17 @@ class TxnCounter : IStressProfile {
             override fun getNextMutation(partitionKey: PartitionKey): Operation =
                 Operation.Mutation(
                     if (accordAutoRead) {
-                        update.bind(partitionKey)
+                        update.bind(partitionKey.getText())
                     } else {
-                        update.bind(partitionKey, partitionKey)
+                        update.bind(partitionKey.getText(), partitionKey.getText())
                     },
                 )
 
             override fun getNextPopulate(partitionKey: PartitionKey): Operation =
-                Operation.Mutation(prepareInsert.bind(partitionKey, partitionKey))
+                Operation.Mutation(prepareInsert.bind(partitionKey.getText(), partitionKey.getText()))
 
-            override fun getNextSelect(partitionKey: PartitionKey): Operation = Operation.SelectStatement(select.bind(partitionKey))
+            override fun getNextSelect(partitionKey: PartitionKey): Operation =
+                Operation.SelectStatement(select.bind(partitionKey.getText()))
 
             override fun getNextDelete(partitionKey: PartitionKey): Operation {
                 TODO("Counter test does not support delete")


### PR DESCRIPTION
Test case

# LWT

```
$ ./bin/cassandra-easy-stress run TxnCounter --duration 30s --workload.impl=LWT --workload.postfix="validate"
Creating easy_cass_stress:
CREATE KEYSPACE
 IF NOT EXISTS easy_cass_stress
 WITH replication = {'class': 'SimpleStrategy', 'replication_factor':3 }

Executing 1000000 operations with consistency level LOCAL_ONE and serial consistency level LOCAL_SERIAL
Connected to Cassandra cluster.
Creating Tables
CREATE TABLE IF NOT EXISTS tx_lwt_counter_validate (
    id TEXT PRIMARY KEY,
    value INT
)
 WITH caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'} AND default_time_to_live = 0
...
                 Writes                                  Reads                                  Deletes                       Errors
  Count  Latency (p99)  1min (req/s) |   Count  Latency (p99)  1min (req/s) |   Count  Latency (p99)  1min (req/s) |   Count  1min (errors/s)
   1754          39.59             0 |      13          15.66             0 |       0              0             0 |       0                0
   3243          38.74         546.8 |      22          15.66           3.6 |       0              0             0 |       0                0
   4725          38.56         546.8 |      38          15.66           3.6 |       0              0             0 |       0                0
   7206          37.53        542.69 |      62          15.66          3.68 |       0              0             0 |       0                0
  10168          36.14        578.18 |      96          13.68          4.27 |       0              0             0 |       0                0
  14629          25.49        578.18 |     140          13.68          4.27 |       0              0             0 |       0                0
```

# Accord

```
$ ./bin/cassandra-easy-stress run TxnCounter --duration 30s --workload.impl=ACCORD --workload.postfix="validate"
Creating easy_cass_stress:
CREATE KEYSPACE
 IF NOT EXISTS easy_cass_stress
 WITH replication = {'class': 'SimpleStrategy', 'replication_factor':3 }

Executing 1000000 operations with consistency level LOCAL_ONE and serial consistency level LOCAL_SERIAL
Connected to Cassandra cluster.
Creating Tables
CREATE TABLE IF NOT EXISTS tx_accord_counter_validate (
    id TEXT PRIMARY KEY,
    value INT
)
WITH transactional_mode='full' AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'} AND default_time_to_live = 0
...
                 Writes                                  Reads                                  Deletes                       Errors
  Count  Latency (p99)  1min (req/s) |   Count  Latency (p99)  1min (req/s) |   Count  Latency (p99)  1min (req/s) |   Count  1min (errors/s)
   1096         202.11             0 |       2          15.41             0 |       0              0             0 |       0                0
   2584         165.04         414.4 |      15          15.41           2.6 |       0              0             0 |       0                0
   4067         132.47         414.4 |      30          15.41           2.6 |       0              0             0 |       0                0
   6545          27.67        420.91 |      53          15.41          2.74 |       0              0             0 |       0                0
   9527           4.52        466.44 |      74          15.41          3.15 |       0              0             0 |       0                0
  13984           3.18        466.44 |     121           9.05          3.15 |       0              0             0 |       0                0
  18939            2.5        547.79 |     171           9.05          4.19 |       0              0             0 |       0                0
  24879           2.44        547.79 |     231           7.19          4.19 |       0              0             0 |       0                0
  31821           1.69        662.28 |     293           3.15          5.36 |       0              0             0 |       0                0
  39242           1.94        807.06 |     378           3.15          6.98 |       0              0             0 |       0                0
```


# Tables

```
cqlsh> describe easy_cass_stress
...
CREATE TABLE easy_cass_stress.tx_accord_counter_validate (
    id text PRIMARY KEY,
    value int
) WITH additional_write_policy = '99p'
...
    AND transactional_mode = 'full'
    AND transactional_migration_from = 'none'
    AND speculative_retry = '99p';
...
CREATE TABLE easy_cass_stress.tx_lwt_counter_validate (
    id text PRIMARY KEY,
    value int
) WITH additional_write_policy = '99p'
...
    AND transactional_mode = 'off'
    AND transactional_migration_from = 'none'
    AND speculative_retry = '99p';
```