### PR TITLE
Upgrade Gradle to 8.14.3 and migrate to version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,24 +16,14 @@
  * limitations under the License.
  */
 
-buildscript {
-    ext.kotlin_version = '1.9.0'
-
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:5.1.0'
-    }
-}
-
 plugins {
-    id 'com.google.cloud.tools.jib' version '3.3.0'
-    id "org.jetbrains.kotlin.jvm" version "1.9.0"
-    id "nebula.ospackage" version "9.1.1"
-    id "nebula.ospackage-application"  version "9.1.1"
-    id "org.jlleitschuh.gradle.ktlint" version "12.1.2"
-    id "io.gitlab.arturbosch.detekt" version "1.23.7"
+    alias(libs.plugins.jib)
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.nebula.ospackage)
+    alias(libs.plugins.nebula.ospackage.application)
+    alias(libs.plugins.ktlint)
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.shadow)
 }
 
 
@@ -41,7 +31,6 @@ apply plugin: 'idea'
 apply plugin: 'java'
 apply plugin: 'kotlin'
 apply plugin: 'application'
-apply plugin: 'com.github.johnrengelman.shadow'
 
 group 'org.apache.cassandra'
 
@@ -57,66 +46,50 @@ repositories {
 }
 
 dependencies {
-//    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.10"
-    implementation group: 'com.beust', name: 'jcommander', version: '1.82'
-
-    // https://mvnrepository.com/artifact/org.apache.commons/commons-text
-    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.3'
+    implementation libs.jcommander
+    implementation libs.commons.text
+    implementation libs.commons.math3
 
     // Java driver v4
-    implementation "org.apache.cassandra:java-driver-core:4.19.0"
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.13.4'
+    implementation libs.cassandra.driver.core
+    implementation libs.jackson.module.kotlin
 
-    // https://mvnrepository.com/artifact/org.reflections/reflections
-    implementation group: 'org.reflections', name: 'reflections', version: '0.9.11'
+    implementation libs.reflections
 
-    implementation group: "org.apache.logging.log4j", name: "log4j-api", version: "2.17.1"
-    implementation group: "org.apache.logging.log4j", name: "log4j-core", version:"2.17.1"
-    implementation 'org.apache.logging.log4j:log4j-api-kotlin:1.2.0'
-    // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-slf4j18-impl
+    // Logging
+    implementation libs.log4j.api
+    implementation libs.log4j.core
+    implementation libs.log4j.api.kotlin
     // maps the datastax driver slf4j calls to log4j
-
-    implementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.18.0'
+    implementation libs.log4j.slf4j18.impl
 
     // needed for yaml logging configurations
+    implementation libs.jackson.databind
+    implementation libs.jackson.dataformat.yaml
 
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4'
+    // Metrics
+    implementation libs.dropwizard.metrics.core
+    implementation libs.prometheus.simpleclient
+    implementation libs.prometheus.simpleclient.dropwizard
+    implementation libs.prometheus.simpleclient.httpserver
 
-    // https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core
-    // Newer version to work with Cassandra driver v4
-    implementation group: 'io.dropwizard.metrics', name: 'metrics-core', version: '4.1.18'
+    implementation libs.guava
+    implementation libs.mordant
+    implementation libs.progressbar
+    implementation libs.hdrhistogram
+    implementation libs.agrona // can't use the 2.x or 1.23+ line as it requires JDK 17
 
-    // https://mvnrepository.com/artifact/com.google.guava/guava
-    implementation group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'
+    // Parquet support
+    implementation libs.parquet.hadoop
+    implementation libs.hadoop.common
+    implementation libs.hadoop.mapreduce.client.common
 
-    // https://mvnrepository.com/artifact/com.github.ajalt/mordant
-    implementation group: 'com.github.ajalt', name: 'mordant', version: '1.1.0'
-
-    implementation 'io.prometheus:simpleclient:0.16.0'
-    implementation 'io.prometheus:simpleclient_dropwizard:0.16.0'
-    implementation 'io.prometheus:simpleclient_httpserver:0.16.0'
-
-    implementation group: 'me.tongfei', name: 'progressbar', version: '0.7.2'
-
-    implementation 'org.apache.commons:commons-math3:3.6.1'
-    implementation 'org.hdrhistogram:HdrHistogram:2.1.12'
-
-    implementation("org.agrona:agrona:1.22.0") // can't use the 2.x or 1.23+ line as it requires JDK 17
-
-    // for Parquet support
-    implementation("org.apache.parquet:parquet-hadoop:1.15.2")
-    implementation 'org.apache.hadoop:hadoop-common:3.4.1'
-    implementation 'org.apache.hadoop:hadoop-mapreduce-client-common:3.4.1'
-
-    // exporting dropwizard metrics
-
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.1.0'
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.9.1'
-    testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '5.4.0'
-
-    testImplementation 'io.mockk:mockk:1.12.7'
+    // Test dependencies
+    testImplementation libs.junit.jupiter.engine
+    testImplementation libs.junit.jupiter.params
+    testImplementation libs.assertj.core
+    testImplementation libs.kotlin.test.junit
+    testImplementation libs.mockk
 
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,82 @@
+[versions]
+kotlin = "2.2.20"
+jib = "3.3.0"
+nebula-ospackage = "12.1.1"
+ktlint = "12.1.2"
+detekt = "1.23.7"
+shadow = "9.2.2"
+
+jcommander = "1.82"
+commons-text = "1.3"
+commons-math3 = "3.6.1"
+cassandra-driver = "4.19.0"
+jackson = "2.17.1"
+jackson-kotlin = "2.13.4"
+jackson-yaml = "2.13.4"
+reflections = "0.9.11"
+log4j = "2.17.1"
+log4j-kotlin = "1.2.0"
+log4j-slf4j = "2.18.0"
+dropwizard-metrics = "4.1.18"
+guava = "32.1.3-jre"
+mordant = "1.1.0"
+prometheus = "0.16.0"
+progressbar = "0.7.2"
+hdrhistogram = "2.1.12"
+agrona = "1.22.0"
+parquet = "1.15.2"
+hadoop = "3.4.1"
+junit = "5.1.0"
+junit-params = "5.4.0"
+assertj = "3.9.1"
+mockk = "1.12.7"
+
+[libraries]
+jcommander = { module = "com.beust:jcommander", version.ref = "jcommander" }
+commons-text = { module = "org.apache.commons:commons-text", version.ref = "commons-text" }
+commons-math3 = { module = "org.apache.commons:commons-math3", version.ref = "commons-math3" }
+
+cassandra-driver-core = { module = "org.apache.cassandra:java-driver-core", version.ref = "cassandra-driver" }
+
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson-kotlin" }
+jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson-yaml" }
+
+reflections = { module = "org.reflections:reflections", version.ref = "reflections" }
+
+log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
+log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
+log4j-api-kotlin = { module = "org.apache.logging.log4j:log4j-api-kotlin", version.ref = "log4j-kotlin" }
+log4j-slf4j18-impl = { module = "org.apache.logging.log4j:log4j-slf4j18-impl", version.ref = "log4j-slf4j" }
+
+dropwizard-metrics-core = { module = "io.dropwizard.metrics:metrics-core", version.ref = "dropwizard-metrics" }
+
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
+mordant = { module = "com.github.ajalt:mordant", version.ref = "mordant" }
+
+prometheus-simpleclient = { module = "io.prometheus:simpleclient", version.ref = "prometheus" }
+prometheus-simpleclient-dropwizard = { module = "io.prometheus:simpleclient_dropwizard", version.ref = "prometheus" }
+prometheus-simpleclient-httpserver = { module = "io.prometheus:simpleclient_httpserver", version.ref = "prometheus" }
+
+progressbar = { module = "me.tongfei:progressbar", version.ref = "progressbar" }
+hdrhistogram = { module = "org.hdrhistogram:HdrHistogram", version.ref = "hdrhistogram" }
+agrona = { module = "org.agrona:agrona", version.ref = "agrona" }
+
+parquet-hadoop = { module = "org.apache.parquet:parquet-hadoop", version.ref = "parquet" }
+hadoop-common = { module = "org.apache.hadoop:hadoop-common", version.ref = "hadoop" }
+hadoop-mapreduce-client-common = { module = "org.apache.hadoop:hadoop-mapreduce-client-common", version.ref = "hadoop" }
+
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-params" }
+assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+
+[plugins]
+jib = { id = "com.google.cloud.tools.jib", version.ref = "jib" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+nebula-ospackage = { id = "com.netflix.nebula.ospackage", version.ref = "nebula-ospackage" }
+nebula-ospackage-application = { id = "com.netflix.nebula.ospackage-application", version.ref = "nebula-ospackage" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Upgrade Gradle from 7.6.2 to 8.14.3
- Upgrade Kotlin from 1.9.0 to 2.2.20
- Upgrade Shadow plugin from 5.1.0 to 9.2.2 (com.gradleup.shadow)
- Upgrade Nebula OS Package from 9.1.1 to 12.1.1 (com.netflix.nebula.ospackage)
- Create gradle/libs.versions.toml for centralized dependency management
- Migrate all dependencies and plugins to version catalog references
- Remove buildscript block in favor of plugins DSL
- Organize dependencies by category (logging, metrics, Parquet, test)