### PR TITLE
Add Docker build option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM gradle:8-jdk17 AS builder
+COPY . /workspace
+WORKDIR /workspace
+RUN gradle shadowJar
+
+FROM eclipse-temurin:17
+COPY --from=builder /workspace/build/ build/
+COPY --from=builder /workspace/bin/ bin/
+ENTRYPOINT ["bin/cassandra-easy-stress"]

--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,6 @@ apply plugin: 'application'
 
 group 'org.apache.cassandra'
 
-sourceCompatibility = 11
-
 application {
     applicationName = "cassandra-easy-stress"
     mainClassName = "org.apache.cassandra.easystress.MainKt"
@@ -126,6 +124,32 @@ task generateExamples(type: Exec) {
     description = "Generate examples for documentation"
 }
 
+task dockerBuild(type: Exec) {
+    group = "build"
+    description = "Build docker image via buildx with optional registry and buildx overrides"
+
+    // Allow overriding via command line: -PdockerRegistry=ghcr.io -PdockerBuildxOptions="--platform linux/amd64"
+    def registry = (project.findProperty("dockerRegistry") ?: "ghcr.io")
+    def repository = (project.findProperty("dockerRepository") ?: "apache/${application.applicationName}")
+
+    def versionTag = (project.version?.toString() ?: "")
+    if (!versionTag || versionTag.length() < 1) {
+        versionTag = "latest"
+    }
+
+    def image = "${registry}/${repository}:${versionTag}"
+    def buildxOptions = (project.findProperty("dockerBuildxOptions") ?: "")
+
+    def command = ["docker", "buildx", "build", "--build-arg", "VERSION=${versionTag}", "-t", image]
+    if (!buildxOptions.isEmpty()) {
+        command.addAll(buildxOptions.split("\\s+"))
+    }
+    command.add(".")
+    command.add("--load")
+
+    commandLine command
+}
+
 jib {
     to {
         image = "rustyrazorblade/cassandra-easy-stress"
@@ -177,7 +201,11 @@ applicationDistribution.from("LICENSE.txt") {
 wrapper {
     distributionType = Wrapper.DistributionType.ALL
 }
-targetCompatibility = JavaVersion.VERSION_11
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
 
 detekt {
     toolVersion = "1.23.7"


### PR DESCRIPTION
Provides the ability to build a Docker container of cassandra-easy-stress. This builds the entire program inside the container, but tries to avoid any complexity in the build otherwise. 

We use this as part of our scaling tests in the cass-operator to ensure our databases have some load. 

Two open questions:

* Do you wish me to create a Github ticket to describe the intention? I did not see any consistency in the other commits / PRs doing this. 
* Would you like me to add automated ghcr.io releases in the Github workflow when release happens? I did not know if these are allowed in the apache organization so I didn't add anything yet. But it would provide a way to publish these automatically for other users. 

If latter is not allowed, I can create a fork at k8ssandra organization and release from there. But I'd prefer to keep it in the official repository. 